### PR TITLE
Set portals when replacing data in Persistable

### DIFF
--- a/lib/filemaker/model/persistable.rb
+++ b/lib/filemaker/model/persistable.rb
@@ -96,6 +96,7 @@ module Filemaker
         @new_record = false
         @record_id = record.record_id
         @mod_id = record.mod_id
+        @portals = record.portals
 
         record.keys.each do |fm_field_name|
           # record.keys are all lowercase

--- a/lib/filemaker/version.rb
+++ b/lib/filemaker/version.rb
@@ -1,3 +1,3 @@
 module Filemaker
-  VERSION = '0.0.10'
+  VERSION = '0.0.11'
 end


### PR DESCRIPTION
I can add specs for the Persistable module to cover this. But, wanted to see if not setting @portals here was intentional. 