### PR TITLE
Refactor builder

### DIFF
--- a/lib/filemaker/model/builder.rb
+++ b/lib/filemaker/model/builder.rb
@@ -15,13 +15,6 @@ module Filemaker
         models
       end
 
-      def single(resultset, klass)
-        record = resultset.first
-        object = klass.new
-
-        build(record, object)
-      end
-
       def build(record, object)
         object.instance_variable_set('@new_record', false)
         object.instance_variable_set('@record_id', record.record_id)

--- a/lib/filemaker/model/builder.rb
+++ b/lib/filemaker/model/builder.rb
@@ -9,23 +9,7 @@ module Filemaker
         models = []
 
         resultset.each do |record|
-          object = klass.new
-
-          object.instance_variable_set('@new_record', false)
-          object.instance_variable_set('@record_id', record.record_id)
-          object.instance_variable_set('@mod_id', record.mod_id)
-          object.instance_variable_set('@portals', record.portals)
-
-          record.keys.each do |fm_field_name|
-            # record.keys are all lowercase
-            field = klass.find_field_by_name(fm_field_name)
-            next unless field
-
-            # Because we are using ActiveModel::Dirty, so we hydrate directly.
-            object.attributes[field.name] = field.coerce(record[fm_field_name])
-          end
-
-          models << object
+          models << hydrated_object_from_record(klass.new, record, true)
         end
 
         models
@@ -35,6 +19,10 @@ module Filemaker
         record = resultset.first
         object = klass.new
 
+        hydrated_object_from_record(klass.new, resultset.first)
+      end
+
+      def hydrated_object_from_record(object, record, hydrate_directly = false)
         object.instance_variable_set('@new_record', false)
         object.instance_variable_set('@record_id', record.record_id)
         object.instance_variable_set('@mod_id', record.mod_id)
@@ -42,10 +30,15 @@ module Filemaker
 
         record.keys.each do |fm_field_name|
           # record.keys are all lowercase
-          field = klass.find_field_by_name(fm_field_name)
+          field = object.class.find_field_by_name(fm_field_name)
           next unless field
 
-          object.public_send("#{field.name}=", record[fm_field_name])
+          if hydrate_directly
+            # Because we are using ActiveModel::Dirty, so we hydrate directly.
+            object.attributes[field.name] = field.coerce(record[fm_field_name])
+          else
+            object.public_send("#{field.name}=", record[fm_field_name])
+          end
         end
 
         object

--- a/lib/filemaker/model/builder.rb
+++ b/lib/filemaker/model/builder.rb
@@ -9,7 +9,7 @@ module Filemaker
         models = []
 
         resultset.each do |record|
-          models << hydrated_object_from_record(klass.new, record, true)
+          models << build(record, klass.new)
         end
 
         models
@@ -19,10 +19,10 @@ module Filemaker
         record = resultset.first
         object = klass.new
 
-        hydrated_object_from_record(klass.new, resultset.first)
+        build(record, object)
       end
 
-      def hydrated_object_from_record(object, record, hydrate_directly = false)
+      def build(record, object)
         object.instance_variable_set('@new_record', false)
         object.instance_variable_set('@record_id', record.record_id)
         object.instance_variable_set('@mod_id', record.mod_id)
@@ -33,12 +33,7 @@ module Filemaker
           field = object.class.find_field_by_name(fm_field_name)
           next unless field
 
-          if hydrate_directly
-            # Because we are using ActiveModel::Dirty, so we hydrate directly.
-            object.attributes[field.name] = field.coerce(record[fm_field_name])
-          else
-            object.public_send("#{field.name}=", record[fm_field_name])
-          end
+          object.attributes[field.name] = field.coerce(record[fm_field_name])
         end
 
         object

--- a/lib/filemaker/model/persistable.rb
+++ b/lib/filemaker/model/persistable.rb
@@ -91,7 +91,7 @@ module Filemaker
 
       # If you have calculated field from FileMaker, it will be replaced.
       def replace_new_data(resultset)
-        FileMaker::Model::Builder.hydrated_object_from_record(self, resultset.first, true)
+        FileMaker::Model::Builder.build(resultset.first, self)
       end
     end
   end

--- a/lib/filemaker/model/persistable.rb
+++ b/lib/filemaker/model/persistable.rb
@@ -91,21 +91,7 @@ module Filemaker
 
       # If you have calculated field from FileMaker, it will be replaced.
       def replace_new_data(resultset)
-        record = resultset.first
-
-        @new_record = false
-        @record_id = record.record_id
-        @mod_id = record.mod_id
-        @portals = record.portals
-
-        record.keys.each do |fm_field_name|
-          # record.keys are all lowercase
-          field = self.class.find_field_by_name(fm_field_name)
-          next unless field
-
-          # Because we are using ActiveModel::Dirty, so we hydrate directly.
-          attributes[field.name] = field.coerce(record[fm_field_name])
-        end
+        FileMaker::Model::Builder.hydrated_object_from_record(self, resultset.first, true)
       end
     end
   end

--- a/spec/filemaker/model/builder_spec.rb
+++ b/spec/filemaker/model/builder_spec.rb
@@ -1,0 +1,43 @@
+describe Filemaker::Model::Builder do
+
+  let(:model) { Job }
+  let(:server) { Object.new }
+  let(:xml) { import_xml_as_string('jobs.xml') }
+  let(:resultset) { Filemaker::Resultset.new(server, xml) }
+
+  context '.single' do
+
+    let(:subject) {
+      Filemaker::Model::Builder.single(resultset, model)
+    }
+
+    it 'has portals' do
+      expect(subject.portals.keys).to eq([])
+    end
+
+    it 'has a status' do
+      expect(subject.status).to eq("open")
+    end
+    
+    it 'has an jdid' do
+      expect(subject.jdid).to eq("JID1122")
+    end
+    
+    it 'has a modify_date' do
+      expect(subject.modify_date).to eq(Date.parse('2014-08-12'))
+    end
+  end
+
+  context '.collection' do
+
+    let(:subject) { 
+      Filemaker::Model::Builder.collection(resultset, model)
+    }
+
+    it 'is an array of Jobs' do
+      subject.each do |job|
+        expect(job.class).to be(model)
+      end
+    end
+  end
+end

--- a/spec/filemaker/model/builder_spec.rb
+++ b/spec/filemaker/model/builder_spec.rb
@@ -5,10 +5,10 @@ describe Filemaker::Model::Builder do
   let(:xml) { import_xml_as_string('jobs.xml') }
   let(:resultset) { Filemaker::Resultset.new(server, xml) }
 
-  context '.single' do
+  context '.' do
 
     let(:subject) {
-      Filemaker::Model::Builder.single(resultset, model)
+      Filemaker::Model::Builder.build(resultset.first, model.new)
     }
 
     it 'has portals' do

--- a/spec/filemaker/model/builder_spec.rb
+++ b/spec/filemaker/model/builder_spec.rb
@@ -5,7 +5,7 @@ describe Filemaker::Model::Builder do
   let(:xml) { import_xml_as_string('jobs.xml') }
   let(:resultset) { Filemaker::Resultset.new(server, xml) }
 
-  context '.' do
+  context '.build' do
 
     let(:subject) {
       Filemaker::Model::Builder.build(resultset.first, model.new)

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -18,6 +18,18 @@ class Post
   string :candidate_id, :email
 end
 
+class Job
+  include Filemaker::Model
+
+  database :jobs
+  layout   :jobs
+
+  string :status
+  string :jdid, fm_name: 'JDID'
+  date   :modify_date, fm_name: 'modify date'
+
+end
+
 class MyModel
   include Filemaker::Model
 


### PR DESCRIPTION
This DRYs up Filemaker::Model::Builder by extracting the common code
into a method that I've called `hydrated_object_from_record`. I'm not sure about the name. Furthermore, I'm not really sure about the 3rd parameter, which I've called `hydrate_directly`. 

I don't understand the context of the comment:

>  Because we are using ActiveModel::Dirty, so we hydrate directly.

But I suspect that maybe it's not necessary to hydrate with either attributes[] or public_send. Perhaps attribute[] will suffice in all cases?