### PR TITLE
fix Encoding::CompatibilityError

### DIFF
--- a/lib/filemaker/metadata/field.rb
+++ b/lib/filemaker/metadata/field.rb
@@ -79,7 +79,7 @@ module Filemaker
           value
         end
       rescue StandardError => e
-        warn "Could not coerce #{name}: #{value} due to #{e.message}"
+        warn "Could not coerce #{name}: #{value} due to #{e.message.force_encoding('UTF-8')}"
         value
       end
 


### PR DESCRIPTION
first of all, this fix is for very rare case :(

under below conditions, `e.message` can't be encoded correctly.
- for example, the type of target field of `e.message` (it's #{name}) is `numerical`
- but the value of the field contains `string`
    - yeah, it's amazing but can be applied by script
- in this case `e.message` occurs below error

```
Encoding::CompatibilityError: incompatible character encodings: UTF-8 and ASCII-8BIT
from /home/takiya/pr-section-webapp/vendor/bundle/ruby/2.5.0/gems/filemaker-1.0.0/lib/filemaker/metadata/field.rb:82:in `rescue in raw_cast'
```

to fix it, I append `force_encoding` method :)

note: although executing on console directory, no error occurs, by `cron` executing error occurs