### PR TITLE
nokogiri version bump

### DIFF
--- a/filemaker.gemspec
+++ b/filemaker.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'typhoeus'
-  spec.add_runtime_dependency 'nokogiri'
+  spec.add_runtime_dependency 'nokogiri', '~> 1.10.3'
   spec.add_runtime_dependency 'activemodel'
   spec.add_runtime_dependency 'globalid'
 


### PR DESCRIPTION
resolves #14 

📓 Overview:

- updated nokogiri version in `.gemspec` file to get rid of vulnerability alerts.