### PR TITLE
Fix record editing

### DIFF
--- a/lib/filemaker/model/persistable.rb
+++ b/lib/filemaker/model/persistable.rb
@@ -36,13 +36,14 @@ module Filemaker
 
       def update
         return false unless valid?
-        return true if dirty_attributes.empty?
+        return true if changes.empty?
 
         run_callbacks :update do
           # Will raise `RecordModificationIdMismatchError` if does not match
           options = { modid: mod_id } # Always pass in?
           yield options if block_given?
-          resultset = api.edit(record_id, dirty_attributes, options)
+          fm_attributes = Hash[changes.map{|key, value| [fields[key].fm_name, value[1]] } ]
+          resultset = api.edit(record_id, fm_attributes, options)
           changes_applied
           replace_new_data(resultset)
         end

--- a/lib/filemaker/model/persistable.rb
+++ b/lib/filemaker/model/persistable.rb
@@ -42,7 +42,7 @@ module Filemaker
           # Will raise `RecordModificationIdMismatchError` if does not match
           options = { modid: mod_id } # Always pass in?
           yield options if block_given?
-          fm_attributes = Hash[changes.map{|key, value| [fields[key].fm_name, value[1]] } ]
+          fm_attributes = Hash[ changes.map{ |key, value| [fields[key].fm_name, value[1]] } ]
           resultset = api.edit(record_id, fm_attributes, options)
           changes_applied
           replace_new_data(resultset)


### PR DESCRIPTION
resolves #16 

📓 Overview:

There is a problem when updating records as the `update` function performs a check on `dirty_attributes` method, which is always empty and does not reflect changes, thus `api.edit` is never invoked.
The correct method that we should check is `changes`, which returns the current changes to the record as a hash:
```
record.changes
# {"auth_token"=>["old token", "new token"]}
```

To allow the correct editing on FileMaker server, the hash keys are mapped to their respective `fm_name`, otherwise Filemaker will throw an error saying `Field does not exist`

The code has been tested and it now works properly.


