### PR TITLE
Fix ruby 2.7 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
 rvm:
   - 2.5.0
+  - 2.7.1
 script: "bundle exec rake"

--- a/filemaker.gemspec
+++ b/filemaker.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'typhoeus'
-  spec.add_runtime_dependency 'nokogiri', '~> 1.10.7'
+  spec.add_runtime_dependency 'nokogiri', '~> 1.10.10'
   spec.add_runtime_dependency 'activemodel'
   spec.add_runtime_dependency 'globalid'
 

--- a/lib/filemaker/model/field.rb
+++ b/lib/filemaker/model/field.rb
@@ -53,9 +53,10 @@ module Filemaker
       # Convert to Ruby type situable for making FileMaker query
       def serialize_for_query(value)
         return value if value.nil?
-        return value if value =~ /^==|=\*/
-        return value if value =~ /(\.\.\.)/
-        return value if value =~ /\A(<|<=|>|>=)/
+        str_val = value.to_s
+        return value if str_val =~ /^==|=\*/
+        return value if str_val =~ /(\.\.\.)/
+        return value if str_val =~ /\A(<|<=|>|>=)/
 
         @type.__filemaker_serialize_for_query(value)
       rescue StandardError => e


### PR DESCRIPTION
`warning: deprecated Object#=~ is called on Integer; it always returns
nil`