### PR TITLE
Update nokogiri due to security issue

### DIFF
--- a/filemaker.gemspec
+++ b/filemaker.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'typhoeus'
-  spec.add_runtime_dependency 'nokogiri', '~> 1.10.10'
+  spec.add_runtime_dependency 'nokogiri', '>= 1.11.0.rc4'
   spec.add_runtime_dependency 'activemodel'
   spec.add_runtime_dependency 'globalid'
 


### PR DESCRIPTION
Previous Nokogiri version 1.10.10 has known vulnerabilities, updated to 1.11.0.rc4 as a fix