### PR TITLE
#176475959 - Chore: Bump nokogiri version from 1.10.10 to 1.11.0.rc4

### DIFF
--- a/filemaker.gemspec
+++ b/filemaker.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'typhoeus'
-  spec.add_runtime_dependency 'nokogiri', '~> 1.10.10'
+  spec.add_runtime_dependency 'nokogiri', '>= 1.11.0.rc4'
   spec.add_runtime_dependency 'activemodel'
   spec.add_runtime_dependency 'globalid'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'uri'
 require 'filemaker'
 require 'pry'
 require_relative 'support/xml_loader'


### PR DESCRIPTION
So: we no longer have security vulnerabilities in other repositories 